### PR TITLE
add option to evaluate hyperparameters on validation set

### DIFF
--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -149,10 +149,10 @@ def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance,
     start_time = time.time()
     while deltrack >= tolerance and iter < max_iter:
         # compute updates
-        H,W,Lambda = method.forward(W,H,V,Lambda,C,b0,eps_,phi,results.mask)
+        H,W,Lambda = method.forward(W,H,V,Lambda,C,b0,eps_,phi,mask)
         # compute objective and cost
-        l_ = beta_div(Beta,V,W,H,eps_,results.mask) #this will compute loss on training set (excluding validation set, when mask is passed)
-        cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,results.mask) #this will compute loss on training set (excluding validation set, when mask is passed)
+        l_ = beta_div(Beta,V,W,H,eps_,mask) #this will compute loss on training set (excluding validation set, when mask is passed)
+        cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,mask) #this will compute loss on training set (excluding validation set, when mask is passed)
         # update tracking
         deltrack = torch.max(torch.div(torch.abs(Lambda -lam_previous), (lam_previous+1e-5)))
         lam_previous = Lambda

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -46,9 +46,9 @@ class ARD_NMF:
 
         if use_val_set:
             torch.manual_seed(0) #get the same mask each time
-            self.mask = (torch.rand(self.V.shape) > 0.2).int() #create mask, randomly mask ~20% of data in shape V. Only used when passed
+            self.mask = (torch.rand(self.V.shape) > 0.2).type(self.dtype) #create mask, randomly mask ~20% of data in shape V. Only used when passed
         else:
-            self.mask = torch.ones(self.V.shape)
+            self.mask = torch.ones(self.V.shape, dtype=self.dtype)
 
         self.a = a
         self.prior_W = prior_W

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -130,7 +130,7 @@ def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance,
     # specify GPU
     cuda_string = 'cuda:'+str(cuda_int)
     # copy data to GPU
-    W,H,V,Lambda,C,b0,eps_,phi = results.W.cuda(cuda_string),results.H.cuda(cuda_string),results.V.cuda(cuda_string),results.Lambda.cuda(cuda_string),results.C.cuda(cuda_string),results.b.cuda(cuda_string),results.eps_.cuda(cuda_string),results.phi.cuda(cuda_string)
+    W,H,V,Lambda,C,b0,eps_,phi,mask = results.W.cuda(cuda_string),results.H.cuda(cuda_string),results.V.cuda(cuda_string),results.Lambda.cuda(cuda_string),results.C.cuda(cuda_string),results.b.cuda(cuda_string),results.eps_.cuda(cuda_string),results.phi.cuda(cuda_string),results.mask.cuda(cuda_string)
 
     # tracking variables
     deltrack = 1000

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -45,6 +45,7 @@ class ARD_NMF:
             self.phi = torch.tensor(np.var(self.V)* phi,dtype=dtype,requires_grad=False)
 
         if use_val_set:
+            torch.manual_seed(0) #get the same mask each time
             self.mask = torch.tensor(torch.rand(self.V.shape) > 0.2, dtype=torch.int8) #create mask, randomly mask ~20% of data in shape V. Only used when passed
         else:
             self.mask = torch.ones(self.V.shape)

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -167,12 +167,15 @@ def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance,
 
         iter+=1
     end_time = time.time()
-    if use_val_set:
-        heldout_mask = 1-mask #now select heldout values (inverse of mask), to get validation set performance
-        l_ = beta_div(Beta,V,W,H,eps_,heldout_mask)
-        cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,heldout_mask)
+    if use_val_set: #compute validation set performance
+        heldout_mask = 1-mask #now select heldout values (inverse of mask)
+        val_l_ = beta_div(Beta,V,W,H,eps_,heldout_mask)
+        val_cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,heldout_mask)
         print("validation set objective=%s\tbeta_div=%s" % (cost_.cpu().numpy(),l_.cpu().numpy()))
-    if send_end != None:
-        send_end.send([W.cpu().numpy(),H.cpu().numpy(),mask.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time,])
     else:
-        return W.cpu().numpy(),H.cpu().numpy(),mask.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time #returns validation set cost, if use_val_set=True
+        val_l_ = None
+        val_cost_ = None
+    if send_end != None:
+        send_end.send([W.cpu().numpy(), H.cpu().numpy(), mask.cpu().numpy(), cost_.cpu().numpy(), l_.cpu().numpy(), val_cost_.cpu().numpy(), val_l_.cpu().numpy(), end_time-start_time,])
+    else:
+        return W.cpu().numpy(),H.cpu().numpy(),mask.cpu().numpy(),cost_.cpu().numpy(), l_.cpu().numpy(), val_cost_.cpu().numpy(), val_l_.cpu().numpy(), end_time-start_time 

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -27,10 +27,9 @@ class ARD_NMF:
         self.channel_names = self.dataset.index[zero_idx]
         self.sample_names = self.dataset.columns
         self.dtype = dtype
-        print('NMF class initalized.')
+        print('NMF class initialized.')
 
     def initalize_data(self,a,phi,b,prior_W,prior_H,Beta,K0,use_val_set,dtype = torch.float32):
-
 
         if K0 == None:
             self.K0 = self.M

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -172,6 +172,6 @@ def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance,
         cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,heldout_mask)
         print("validation set objective=%s\tbeta_div=%s" % (cost_.cpu().numpy(),l_.cpu().numpy()))
     if send_end != None:
-        send_end.send([W.cpu().numpy(),H.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time])
+        send_end.send([W.cpu().numpy(),H.cpu().numpy(),mask.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time,])
     else:
-        return W.cpu().numpy(),H.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time #returns validation set cost, if use_val_set=True
+        return W.cpu().numpy(),H.cpu().numpy(),mask.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time #returns validation set cost, if use_val_set=True

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -29,30 +29,33 @@ class ARD_NMF:
         self.dtype = dtype
         print('NMF class initalized.')
 
-    def initalize_data(self,a,phi,b,prior_W,prior_H,Beta,K0,dtype = torch.float32):
-        
-        
+    def initalize_data(self,a,phi,b,prior_W,prior_H,Beta,K0,use_val_set,dtype = torch.float32):
+
+
         if K0 == None:
             self.K0 = self.M
             self.number_of_active_components = self.M
         else:
             self.K0 = K0
             self.number_of_active_components = self.K0
-            
+
         if self.objective.lower() == 'poisson':
-
             self.phi = torch.tensor(phi,dtype=dtype,requires_grad=False)
-
         else:
             self.phi = torch.tensor(np.var(self.V)* phi,dtype=dtype,requires_grad=False)
-        
+
+        if use_val_set:
+            self.mask = torch.tensor(torch.rand(self.V.shape) > 0.2, dtype=torch.int8) #create mask, randomly mask ~20% of data in shape V. Only used when passed
+        else:
+            self.mask = torch.ones(self.V.shape)
+
         self.a = a
         self.prior_W = prior_W
         self.prior_H = prior_H
         self.C = []
         self.b = b
-        
-        
+
+
         W0 = np.multiply(np.random.uniform(size=[self.M, self.K0])+self.eps_.numpy(), np.sqrt(self.V_max))
         H0 = np.multiply(np.random.uniform(size=[self.K0, self.N])+self.eps_.numpy(), np.sqrt(self.V_max))
         L0 = np.sum(W0,axis=0) + np.sum(H0,axis=1)
@@ -66,23 +69,23 @@ class ARD_NMF:
         if self.b == None or self.b == 'None':
             # L1 ARD
             if self.prior_H == 'L1' and self.prior_W == 'L1':
-                
+
                 self.bcpu = np.sqrt(np.true_divide( (self.a - 1)*(self.a - 2) * np.mean(self.V),self.K0 ))
                 self.b = torch.tensor(
                     np.sqrt(np.true_divide( (self.a - 1)*(self.a - 2) * np.mean(self.V),self.K0 ))
                     ,dtype=self.dtype,requires_grad=False)
-                
+
                 self.C = torch.tensor(self.N + self.M + self.a + 1, dtype=self.dtype, requires_grad=False)
             # L2 ARD
             elif self.prior_H == 'L2' and self.prior_W == 'L2':
-                
+
                 self.bcpu = np.true_divide(np.pi * (self.a - 1) * np.mean(self.V),2*self.K0)
                 self.b = torch.tensor(
                     np.true_divide(np.pi * (self.a - 1) * np.mean(self.V),2*self.K0),
                     dtype=self.dtype,requires_grad=False)
-                
+
                 self.C = torch.tensor( (self.N + self.M)*0.5 + self.a + 1, dtype=self.dtype,requires_grad=False)
-                
+
             # L1 - L2 ARD
             elif self.prior_H == 'L1' and self.prior_W == 'L2':
                 self.bcpu = np.true_divide(np.mean(self.V)*np.sqrt(2)*gamma(self.a-3/2),self.K0*np.sqrt(np.pi)*gamma(self.a))
@@ -114,17 +117,20 @@ class ARD_NMF:
         print('NMF data and parameters set.')
     def get_number_of_active_components(self):
         self.number_of_active_components = torch.sum(torch.sum(self.W,0)> 0.0, dtype=self.dtype)
-        
-        
-        
-def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance, max_iter, send_end = None, cuda_int = 0):
+
+
+
+def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance, max_iter, use_val_set=False, send_end = None, cuda_int = 0):
+    """
+    - use_val_set: whether to use validation set. If false (default), set masks to all ones. Otherwise, use 0/1 mask to hold out 0's as validation set during training and will report objective function value for that set.
+    """
     # initalize the NMF run
-    results.initalize_data(a,phi,b,W_prior,H_prior,Beta,K0)
+    results.initalize_data(a,phi,b,W_prior,H_prior,Beta,K0,use_val_set)
     # specify GPU
     cuda_string = 'cuda:'+str(cuda_int)
     # copy data to GPU
-    W,H,V,Lambda,C,b0,eps_,phi = results.W.cuda(cuda_string),results.H.cuda(cuda_string),results.V.cuda(cuda_string),results.Lambda.cuda(cuda_string),results.C.cuda(cuda_string),results.b.cuda(cuda_string),results.eps_.cuda(cuda_string),results.phi.cuda(cuda_string)    
-    
+    W,H,V,Lambda,C,b0,eps_,phi = results.W.cuda(cuda_string),results.H.cuda(cuda_string),results.V.cuda(cuda_string),results.Lambda.cuda(cuda_string),results.C.cuda(cuda_string),results.b.cuda(cuda_string),results.eps_.cuda(cuda_string),results.phi.cuda(cuda_string)
+
     # tracking variables
     deltrack = 1000
     times = list()
@@ -142,25 +148,29 @@ def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance,
     start_time = time.time()
     while deltrack >= tolerance and iter < max_iter:
         # compute updates
-        H,W,Lambda = method.forward(W,H,V,Lambda,C,b0,eps_,phi)
+        H,W,Lambda = method.forward(W,H,V,Lambda,C,b0,eps_,phi,results.mask)
         # compute objective and cost
-        l_ = beta_div(Beta,V,W,H,eps_)
-        cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0)
+        l_ = beta_div(Beta,V,W,H,eps_,results.mask) #this will compute loss on training set (excluding validation set, when mask is passed)
+        cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,results.mask) #this will compute loss on training set (excluding validation set, when mask is passed)
         # update tracking
         deltrack = torch.max(torch.div(torch.abs(Lambda -lam_previous), (lam_previous+1e-5)))
         lam_previous = Lambda
-        
+
         # report to stdout
         if iter % report_freq == 0:
             print("nit=%s\tobjective=%s\tbeta_div=%s\tlambda=%s\tdel=%s\tK=%s\tsumW=%s\tsumH=%s" % (iter,cost_.cpu().numpy(),l_.cpu().numpy(),torch.sum(Lambda).cpu().numpy()
                                                                                                 ,deltrack.cpu().numpy(),
                                                                                                torch.sum((torch.sum(H,1) + torch.sum(W,0))>active_thresh).cpu().numpy()
                                                                                                 ,torch.sum(W).cpu().numpy(),torch.sum(H).cpu().numpy()))
-    
+
         iter+=1
     end_time = time.time()
-    if send_end != None:    
+    if use_val_set:
+        heldout_mask = (results.mask-1)*(-1) #now select heldout values (inverse of mask), to get validation set performance
+        l_ = beta_div(Beta,V,W,H,eps_,heldout_mask)
+        cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,heldout_mask)
+        print("validation set objective=%s\tbeta_div=%s" % (cost_.cpu().numpy(),l_.cpu().numpy()))
+    if send_end != None:
         send_end.send([W.cpu().numpy(),H.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time])
     else:
-        return W.cpu().numpy(),H.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time
-        
+        return W.cpu().numpy(),H.cpu().numpy(),cost_.cpu().numpy(),end_time-start_time #returns validation set cost, if use_val_set=True

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -121,7 +121,7 @@ class ARD_NMF:
 
 
 
-def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance, max_iter, use_val_set=False, send_end = None, cuda_int = 0):
+def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance, max_iter, use_val_set, send_end = None, cuda_int = 0):
     """
     - use_val_set: whether to use validation set. If false (default), set masks to all ones. Otherwise, use 0/1 mask to hold out 0's as validation set during training and will report objective function value for that set.
     """
@@ -167,7 +167,7 @@ def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance,
         iter+=1
     end_time = time.time()
     if use_val_set:
-        heldout_mask = (mask-1)*(-1) #now select heldout values (inverse of mask), to get validation set performance
+        heldout_mask = 1-mask #now select heldout values (inverse of mask), to get validation set performance
         l_ = beta_div(Beta,V,W,H,eps_,heldout_mask)
         cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,heldout_mask)
         print("validation set objective=%s\tbeta_div=%s" % (cost_.cpu().numpy(),l_.cpu().numpy()))

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -167,7 +167,7 @@ def run_method_engine(results, a, phi, b, Beta, W_prior, H_prior, K0, tolerance,
         iter+=1
     end_time = time.time()
     if use_val_set:
-        heldout_mask = (results.mask-1)*(-1) #now select heldout values (inverse of mask), to get validation set performance
+        heldout_mask = (mask-1)*(-1) #now select heldout values (inverse of mask), to get validation set performance
         l_ = beta_div(Beta,V,W,H,eps_,heldout_mask)
         cost_ = calculate_objective_function(Beta,V,W,H,Lambda,C,eps_,phi,results.K0,heldout_mask)
         print("validation set objective=%s\tbeta_div=%s" % (cost_.cpu().numpy(),l_.cpu().numpy()))

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -46,7 +46,7 @@ class ARD_NMF:
 
         if use_val_set:
             torch.manual_seed(0) #get the same mask each time
-            self.mask = torch.tensor(torch.rand(self.V.shape) > 0.2, dtype=dtype,requires_grad=False) #create mask, randomly mask ~20% of data in shape V. Only used when passed
+            self.mask = (torch.rand(self.V.shape) > 0.2).int() #create mask, randomly mask ~20% of data in shape V. Only used when passed
         else:
             self.mask = torch.ones(self.V.shape)
 

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -46,7 +46,7 @@ class ARD_NMF:
 
         if use_val_set:
             torch.manual_seed(0) #get the same mask each time
-            self.mask = torch.tensor(torch.rand(self.V.shape) > 0.2, dtype=torch.int8) #create mask, randomly mask ~20% of data in shape V. Only used when passed
+            self.mask = torch.tensor(torch.rand(self.V.shape) > 0.2, dtype=dtype,requires_grad=False) #create mask, randomly mask ~20% of data in shape V. Only used when passed
         else:
             self.mask = torch.ones(self.V.shape)
 

--- a/ARD_NMF.py
+++ b/ARD_NMF.py
@@ -30,6 +30,8 @@ class ARD_NMF:
         print('NMF class initialized.')
 
     def initalize_data(self,a,phi,b,prior_W,prior_H,Beta,K0,use_val_set,dtype = torch.float32):
+        
+        self.V = np.array(self.V) #when gets called in a loop as in run_parameter_sweep this can get updated to a torch tensor in a previous iteration which breaks some numpy functions
 
         if K0 == None:
             self.K0 = self.M

--- a/NMF_functions.py
+++ b/NMF_functions.py
@@ -78,7 +78,8 @@ def calculate_objective_function(Beta,V,W,H,lambda_,C, eps_,phi,K,mask):
 
 def update_H_poisson_L1(H, W, lambda_, phi, V, eps_,mask):
     #beta = 1 gamma(beta) = 1
-    denom = torch.matmul(W.transpose(1,0), mask) + torch.div(phi, lambda_) + eps_
+
+    denom = torch.matmul(W.transpose(1,0), mask) + torch.div(phi, lambda_).reshape(-1,1) + eps_
     V_ap = torch.matmul(W, H) + eps_
     V_res = torch.div(V*mask, V_ap)
     update = torch.div(torch.matmul(W.transpose(1,0), V_res), denom)

--- a/NMF_functions.py
+++ b/NMF_functions.py
@@ -51,26 +51,28 @@ class NMF_algorithim(nn.Module):
             self.update_H = update_H_gaussian_L2
             self.lambda_update = update_lambda_L2
 
-    def forward(self,W, H, V, lambda_, C, b0, eps_, phi):
-        h_ = self.update_H(H, W, lambda_, phi, V, eps_)
-        w_ = self.update_W(h_, W, lambda_, phi, V, eps_)
+    def forward(self,W, H, V, lambda_, C, b0, eps_, phi, mask):
+        h_ = self.update_H(H, W, lambda_, phi, V, eps_, mask)
+        w_ = self.update_W(h_, W, lambda_, phi, V, eps_, mask)
         lam_ = self.lambda_update(w_,h_,b0,C,eps_)
         return h_, w_,lam_
 
 
 
-def beta_div(Beta,V,W,H,eps_):
-    
+def beta_div(Beta,V,W,H,eps_,mask):
     V_ap = torch.matmul(W, H).type(V.dtype) + eps_.type(V.dtype)
     if Beta == 2:
-        return SEloss(V,V_ap)/2
+        return SEloss(V*mask,V_ap*mask)/2
     if Beta == 1:
-        
         lr = torch.log(torch.div(V, V_ap))
-        return torch.sum((V*lr) - V + V_ap)
+        return torch.sum((V*mask*lr) - V*mask + V_ap*mask)
 
-def calculate_objective_function(Beta,V,W,H,lambda_,C, eps_,phi,K):
-    loss = beta_div(Beta,V,W,H,eps_)
+def calculate_objective_function(Beta,V,W,H,lambda_,C, eps_,phi,K,mask):
+    """
+    If a validation set is being used, this will mask heldout set when evaluating objective function during training.
+    Can calculate validation set objective value by passing inverse mask.
+    """
+    loss = beta_div(Beta,V,W,H,eps_,mask)
     cst = (K*C)*(1.0-torch.log(C))
     return torch.pow(phi,-1)*loss + (C*torch.sum(torch.log(lambda_ * C))) + cst
 
@@ -78,7 +80,7 @@ def update_H_poisson_L1(H, W, lambda_, phi, V, eps_):
     #beta = 1 gamma(beta) = 1
     denom = torch.sum(W, 0) + torch.div(phi, lambda_) + eps_
     V_ap = torch.matmul(W, H) + eps_
-    V_res = torch.div(V, V_ap)
+    V_res = torch.div(V*mask, V_ap)
     update = torch.div(torch.matmul(W.transpose(1,0), V_res), denom.reshape(-1,1))
     return H * update
 
@@ -86,34 +88,34 @@ def update_H_poisson_L2(H,W,lambda_,phi,V, eps_):
     #beta = 1 zeta(beta) = 1/2
     denom = torch.sum(W,0).reshape(-1,1) + torch.div(phi*H, lambda_.reshape(-1,1)) + eps_
     V_ap = torch.matmul(W, H) + eps_
-    update = torch.pow(torch.div(torch.matmul(W.transpose(0,1), torch.div(V, V_ap)), denom),0.5)
+    update = torch.pow(torch.div(torch.matmul(W.transpose(0,1), torch.div(V*mask, V_ap)), denom),0.5)
     return H * update
 
 def update_H_gaussian_L1(H,W,lambda_,phi,V,eps_):
     #beta = 2 gamma(beta) = 1
     V_ap = torch.matmul(W, H) + eps_
     denom = torch.matmul(W.transpose(0,1),V_ap) + torch.div(phi, lambda_ ).reshape(-1,1) + eps_
-    update = torch.div(torch.matmul(W.transpose(0,1),V),denom)
+    update = torch.div(torch.matmul(W.transpose(0,1),V*mask),denom)
     return H * update
 
 def update_H_gaussian_L2(H,W,lambda_,phi,V,eps_):
     #beta = 2 zeta(beta) = 1
     denom = torch.matmul(W.transpose(0,1).type(V.dtype),torch.matmul(W, H).type(V.dtype) + eps_) + torch.div(phi * H, lambda_.reshape(-1,1)).type(V.dtype) + eps_
-    update = torch.div(torch.matmul(W.transpose(0,1).type(V.dtype),V),denom)
+    update = torch.div(torch.matmul(W.transpose(0,1).type(V.dtype),V*mask),denom)
     return H * update.type(torch.float32)
 
 def update_W_poisson_L1(H, W, lambda_, phi, V, eps_):
     #beta = 1 gamma(beta) = 1
     denom = torch.sum(H, 1) + torch.div(phi, lambda_ ) + eps_
     V_ap = torch.matmul(W, H) + eps_
-    V_res = torch.div(V, V_ap)
+    V_res = torch.div(V*mask, V_ap)
     update = torch.div(torch.matmul(V_res, H.transpose(0,1)), denom)
     return W * update
 
 def update_W_poisson_L2(H,W,lambda_,phi,V,eps_):
     # beta = 1 zeta(beta) = 1/2
     V_ap = torch.matmul(W,H) + eps_
-    V_res = torch.div(V, V_ap)
+    V_res = torch.div(V*mask, V_ap)
     denom = torch.sum(H,1) + torch.div(phi*W,lambda_) + eps_
     update = torch.pow(torch.div(torch.matmul(V_res,H.transpose(0,1)),denom),0.5)
     return W * update
@@ -122,14 +124,14 @@ def update_W_gaussian_L1(H,W,lambda_,phi,V,eps_):
     #beta = 2 gamma(beta) = 1
     V_ap = torch.matmul(W,H).type(V.dtype) + eps_
     denom = torch.matmul(V_ap,H.transpose(0,1).type(V.dtype)) + torch.div(phi,lambda_).type(V.dtype) + eps_
-    update = torch.div(torch.matmul(V,H.transpose(0,1).type(V.dtype)),denom)
+    update = torch.div(torch.matmul(V*mask,H.transpose(0,1).type(V.dtype)),denom)
     return W * update.type(torch.float32)
 
 def update_W_gaussian_L2(H,W,lambda_,phi,V,eps_):
     #beta = 2 zeta(beta) = 1
     V_ap = torch.matmul(W,H) + eps_
     denom = torch.matmul(V_ap,H.transpose(0,1)) + torch.div(phi*W,lambda_) + eps_
-    update = torch.div(torch.matmul(V,H.transpose(0,1)),denom)
+    update = torch.div(torch.matmul(V*mask,H.transpose(0,1)),denom)
     return W * update
 
 # update tolerance value for early stop criteria
@@ -150,4 +152,3 @@ def update_lambda_L1_L2(W,H,b0,C,eps_):
 
 def update_lambda_L2_L1(W,H,b0,C,eps_):
     return torch.div(0.5*torch.sum(torch.pow(W,2),0) + torch.sum(H,1)+b0,C)
-

--- a/NMF_functions.py
+++ b/NMF_functions.py
@@ -76,7 +76,7 @@ def calculate_objective_function(Beta,V,W,H,lambda_,C, eps_,phi,K,mask):
     cst = (K*C)*(1.0-torch.log(C))
     return torch.pow(phi,-1)*loss + (C*torch.sum(torch.log(lambda_ * C))) + cst
 
-def update_H_poisson_L1(H, W, lambda_, phi, V, eps_):
+def update_H_poisson_L1(H, W, lambda_, phi, V, eps_,mask):
     #beta = 1 gamma(beta) = 1
     denom = torch.sum(W, 0) + torch.div(phi, lambda_) + eps_
     V_ap = torch.matmul(W, H) + eps_
@@ -84,27 +84,27 @@ def update_H_poisson_L1(H, W, lambda_, phi, V, eps_):
     update = torch.div(torch.matmul(W.transpose(1,0), V_res), denom.reshape(-1,1))
     return H * update
 
-def update_H_poisson_L2(H,W,lambda_,phi,V, eps_):
+def update_H_poisson_L2(H,W,lambda_,phi,V, eps_,mask):
     #beta = 1 zeta(beta) = 1/2
     denom = torch.sum(W,0).reshape(-1,1) + torch.div(phi*H, lambda_.reshape(-1,1)) + eps_
     V_ap = torch.matmul(W, H) + eps_
     update = torch.pow(torch.div(torch.matmul(W.transpose(0,1), torch.div(V*mask, V_ap)), denom),0.5)
     return H * update
 
-def update_H_gaussian_L1(H,W,lambda_,phi,V,eps_):
+def update_H_gaussian_L1(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 gamma(beta) = 1
     V_ap = torch.matmul(W, H) + eps_
     denom = torch.matmul(W.transpose(0,1),V_ap) + torch.div(phi, lambda_ ).reshape(-1,1) + eps_
     update = torch.div(torch.matmul(W.transpose(0,1),V*mask),denom)
     return H * update
 
-def update_H_gaussian_L2(H,W,lambda_,phi,V,eps_):
+def update_H_gaussian_L2(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 zeta(beta) = 1
     denom = torch.matmul(W.transpose(0,1).type(V.dtype),torch.matmul(W, H).type(V.dtype) + eps_) + torch.div(phi * H, lambda_.reshape(-1,1)).type(V.dtype) + eps_
     update = torch.div(torch.matmul(W.transpose(0,1).type(V.dtype),V*mask),denom)
     return H * update.type(torch.float32)
 
-def update_W_poisson_L1(H, W, lambda_, phi, V, eps_):
+def update_W_poisson_L1(H, W, lambda_, phi, V, eps_,mask):
     #beta = 1 gamma(beta) = 1
     denom = torch.sum(H, 1) + torch.div(phi, lambda_ ) + eps_
     V_ap = torch.matmul(W, H) + eps_
@@ -112,7 +112,7 @@ def update_W_poisson_L1(H, W, lambda_, phi, V, eps_):
     update = torch.div(torch.matmul(V_res, H.transpose(0,1)), denom)
     return W * update
 
-def update_W_poisson_L2(H,W,lambda_,phi,V,eps_):
+def update_W_poisson_L2(H,W,lambda_,phi,V,eps_,mask):
     # beta = 1 zeta(beta) = 1/2
     V_ap = torch.matmul(W,H) + eps_
     V_res = torch.div(V*mask, V_ap)
@@ -120,14 +120,14 @@ def update_W_poisson_L2(H,W,lambda_,phi,V,eps_):
     update = torch.pow(torch.div(torch.matmul(V_res,H.transpose(0,1)),denom),0.5)
     return W * update
 
-def update_W_gaussian_L1(H,W,lambda_,phi,V,eps_):
+def update_W_gaussian_L1(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 gamma(beta) = 1
     V_ap = torch.matmul(W,H).type(V.dtype) + eps_
     denom = torch.matmul(V_ap,H.transpose(0,1).type(V.dtype)) + torch.div(phi,lambda_).type(V.dtype) + eps_
     update = torch.div(torch.matmul(V*mask,H.transpose(0,1).type(V.dtype)),denom)
     return W * update.type(torch.float32)
 
-def update_W_gaussian_L2(H,W,lambda_,phi,V,eps_):
+def update_W_gaussian_L2(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 zeta(beta) = 1
     V_ap = torch.matmul(W,H) + eps_
     denom = torch.matmul(V_ap,H.transpose(0,1)) + torch.div(phi*W,lambda_) + eps_

--- a/NMF_functions.py
+++ b/NMF_functions.py
@@ -78,15 +78,15 @@ def calculate_objective_function(Beta,V,W,H,lambda_,C, eps_,phi,K,mask):
 
 def update_H_poisson_L1(H, W, lambda_, phi, V, eps_,mask):
     #beta = 1 gamma(beta) = 1
-    denom = torch.sum(W, 0) + torch.div(phi, lambda_) + eps_
+    denom = torch.matmul(W.transpose(1,0), mask) + torch.div(phi, lambda_) + eps_
     V_ap = torch.matmul(W, H) + eps_
     V_res = torch.div(V*mask, V_ap)
-    update = torch.div(torch.matmul(W.transpose(1,0), V_res), denom.reshape(-1,1))
+    update = torch.div(torch.matmul(W.transpose(1,0), V_res), denom)
     return H * update
 
 def update_H_poisson_L2(H,W,lambda_,phi,V, eps_,mask):
     #beta = 1 zeta(beta) = 1/2
-    denom = torch.sum(W,0).reshape(-1,1) + torch.div(phi*H, lambda_.reshape(-1,1)) + eps_
+    denom = torch.matmul(W.transpose(1,0), mask) + torch.div(phi*H, lambda_.reshape(-1,1)) + eps_
     V_ap = torch.matmul(W, H) + eps_
     update = torch.pow(torch.div(torch.matmul(W.transpose(0,1), torch.div(V*mask, V_ap)), denom),0.5)
     return H * update
@@ -94,19 +94,20 @@ def update_H_poisson_L2(H,W,lambda_,phi,V, eps_,mask):
 def update_H_gaussian_L1(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 gamma(beta) = 1
     V_ap = torch.matmul(W, H) + eps_
-    denom = torch.matmul(W.transpose(0,1),V_ap) + torch.div(phi, lambda_ ).reshape(-1,1) + eps_
+    denom = torch.matmul(W.transpose(0,1),V_ap*mask) + torch.div(phi, lambda_ ).reshape(-1,1) + eps_
     update = torch.div(torch.matmul(W.transpose(0,1),V*mask),denom)
     return H * update
 
 def update_H_gaussian_L2(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 zeta(beta) = 1
-    denom = torch.matmul(W.transpose(0,1).type(V.dtype),torch.matmul(W, H).type(V.dtype) + eps_) + torch.div(phi * H, lambda_.reshape(-1,1)).type(V.dtype) + eps_
+    V_ap = torch.matmul(W, H).type(V.dtype) + eps_
+    denom = torch.matmul(W.transpose(0,1).type(V.dtype),V_ap*mask) + torch.div(phi * H, lambda_.reshape(-1,1)).type(V.dtype) + eps_
     update = torch.div(torch.matmul(W.transpose(0,1).type(V.dtype),V*mask),denom)
     return H * update.type(torch.float32)
 
 def update_W_poisson_L1(H, W, lambda_, phi, V, eps_,mask):
     #beta = 1 gamma(beta) = 1
-    denom = torch.sum(H, 1) + torch.div(phi, lambda_ ) + eps_
+    denom = torch.matmul(mask, H.transpose(1,0)) + torch.div(phi, lambda_ ) + eps_
     V_ap = torch.matmul(W, H) + eps_
     V_res = torch.div(V*mask, V_ap)
     update = torch.div(torch.matmul(V_res, H.transpose(0,1)), denom)
@@ -116,21 +117,21 @@ def update_W_poisson_L2(H,W,lambda_,phi,V,eps_,mask):
     # beta = 1 zeta(beta) = 1/2
     V_ap = torch.matmul(W,H) + eps_
     V_res = torch.div(V*mask, V_ap)
-    denom = torch.sum(H,1) + torch.div(phi*W,lambda_) + eps_
+    denom = torch.matmul(mask, H.transpose(1,0)) + torch.div(phi*W,lambda_) + eps_
     update = torch.pow(torch.div(torch.matmul(V_res,H.transpose(0,1)),denom),0.5)
     return W * update
 
 def update_W_gaussian_L1(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 gamma(beta) = 1
     V_ap = torch.matmul(W,H).type(V.dtype) + eps_
-    denom = torch.matmul(V_ap,H.transpose(0,1).type(V.dtype)) + torch.div(phi,lambda_).type(V.dtype) + eps_
+    denom = torch.matmul(V_ap*mask,H.transpose(0,1).type(V.dtype)) + torch.div(phi,lambda_).type(V.dtype) + eps_
     update = torch.div(torch.matmul(V*mask,H.transpose(0,1).type(V.dtype)),denom)
     return W * update.type(torch.float32)
 
 def update_W_gaussian_L2(H,W,lambda_,phi,V,eps_,mask):
     #beta = 2 zeta(beta) = 1
     V_ap = torch.matmul(W,H) + eps_
-    denom = torch.matmul(V_ap,H.transpose(0,1)) + torch.div(phi*W,lambda_) + eps_
+    denom = torch.matmul(V_ap*mask,H.transpose(0,1)) + torch.div(phi*W,lambda_) + eps_
     update = torch.div(torch.matmul(V*mask,H.transpose(0,1)),denom)
     return W * update
 

--- a/SignatureAnalyzer-GPU.py
+++ b/SignatureAnalyzer-GPU.py
@@ -55,7 +55,6 @@ def run_parameter_sweep(parameters,data,args,Beta):
 
     if idx < len(parameters):
         for i in range(len(parameters)-idx):
-            idx+=i
             W,H,mask,cost,time = run_method_engine(data, parameters.iloc[idx]['a'], parameters.iloc[idx]['phi'], parameters.iloc[idx]['b'], Beta,
                                                    args.prior_on_W, args.prior_on_H, parameters.iloc[idx]['K0'], args.tolerance, args.max_iter, args.use_val_set)
             nsig = write_output(W,H,mask,data.channel_names,data.sample_names,args.output_dir,
@@ -63,6 +62,7 @@ def run_parameter_sweep(parameters,data,args,Beta):
             times.append(time)
             nsigs.append(nsig)
             objectives.append(cost)
+            idx+=i
     parameters['nsigs'] = nsigs
     parameters['objective'] = objectives
     parameters['times'] = times

--- a/SignatureAnalyzer-GPU.py
+++ b/SignatureAnalyzer-GPU.py
@@ -38,7 +38,7 @@ def run_parameter_sweep(parameters,data,args,Beta):
         for rank in range(num_processes):
             recv_end, send_end = mp.Pipe(False)
             p = mp.Process(target=run_method_engine, args=(data, parameters.iloc[idx+rank]['a'], parameters.iloc[idx+rank]['phi'], parameters.iloc[idx+rank]['b'], Beta,
-                                                   args.prior_on_W, args.prior_on_H, parameters.iloc[idx+rank]['K0'], args.tolerance, args.max_iter, use_val_set=True, send_end=send_end, cuda_int=rank,))
+                                                   args.prior_on_W, args.prior_on_H, parameters.iloc[idx+rank]['K0'], args.tolerance, args.max_iter, True, send_end, rank,))
             pipe_list.append(recv_end)
             processes.append(p)
             p.start()

--- a/SignatureAnalyzer-GPU.py
+++ b/SignatureAnalyzer-GPU.py
@@ -55,6 +55,7 @@ def run_parameter_sweep(parameters,data,args,Beta):
 
     if idx < len(parameters):
         for i in range(len(parameters)-idx):
+            idx+=i
             print(idx)
             W,H,mask,cost,time = run_method_engine(data, parameters.iloc[idx]['a'], parameters.iloc[idx]['phi'], parameters.iloc[idx]['b'], Beta,
                                                    args.prior_on_W, args.prior_on_H, parameters.iloc[idx]['K0'], args.tolerance, args.max_iter, args.use_val_set)
@@ -63,7 +64,6 @@ def run_parameter_sweep(parameters,data,args,Beta):
             times.append(time)
             nsigs.append(nsig)
             objectives.append(cost)
-            idx+=i
     parameters['nsigs'] = nsigs
     parameters['objective'] = objectives
     parameters['times'] = times

--- a/SignatureAnalyzer-GPU.py
+++ b/SignatureAnalyzer-GPU.py
@@ -88,7 +88,7 @@ def write_output(W, H, mask, channel_names, sample_names, output_directory, labe
             # Write W and H matrices
             W_df.to_csv(output_directory + '/'+label+ '_W.txt', sep='\t')
             H_df.to_csv(output_directory + '/'+label+ '_H.txt', sep='\t')
-            mask_df.to_csv(output_directory + '/'+label+ '_H.txt', sep='\t')
+            mask_df.to_csv(output_directory + '/'+label+ '_mask.txt', sep='\t')
 
 
             return nsig

--- a/SignatureAnalyzer-GPU.py
+++ b/SignatureAnalyzer-GPU.py
@@ -29,6 +29,9 @@ def run_parameter_sweep(parameters,data,args,Beta):
     batches = int(len(parameters) / num_processes)
     idx = 0
     objectives = []
+    bdivs = []
+    val_objectives = []
+    val_bdivs = []
     nsigs = []
     times = []
     while idx <= len(parameters)-num_processes:
@@ -49,23 +52,32 @@ def run_parameter_sweep(parameters,data,args,Beta):
         nsig = [write_output(x[0],x[1],x[2],data.channel_names,data.sample_names,args.output_dir,
                       parameters['label'][idx+i]) for i,x in enumerate(result_list)]
         [nsigs.append(ns) for i,ns in enumerate(nsig)]
-        [times.append(time[4]) for i,time in enumerate(result_list)]
         [objectives.append(obj[3]) for i,obj in enumerate(result_list)]
+        [bdivs.append(obj[4]) for i,obj in enumerate(result_list)]
+        [val_objectives.append(obj[5]) for i,obj in enumerate(result_list)]
+        [val_bdivs.append(obj[6]) for i,obj in enumerate(result_list)]
+        [times.append(time[7]) for i,time in enumerate(result_list)]
         idx += num_processes
 
     if idx < len(parameters):
         for i in range(len(parameters)-idx):
             idx+=i
             print(idx)
-            W,H,mask,cost,time = run_method_engine(data, parameters.iloc[idx]['a'], parameters.iloc[idx]['phi'], parameters.iloc[idx]['b'], Beta,
+            W,H,mask,cost,bdiv,val_cost,val_bdiv,time = run_method_engine(data, parameters.iloc[idx]['a'], parameters.iloc[idx]['phi'], parameters.iloc[idx]['b'], Beta,
                                                    args.prior_on_W, args.prior_on_H, parameters.iloc[idx]['K0'], args.tolerance, args.max_iter, args.use_val_set)
             nsig = write_output(W,H,mask,data.channel_names,data.sample_names,args.output_dir,
                       parameters['label'][idx])
             times.append(time)
             nsigs.append(nsig)
             objectives.append(cost)
+            val_objectives.append(val_cost)
+            bdivs.append(bdiv)
+            val_bdivs.append(val_bdiv)
     parameters['nsigs'] = nsigs
-    parameters['objective'] = objectives
+    parameters['objective_trainset'] = objectives
+    parameters['bdiv_trainset'] = bdivs
+    parameters['objective_valset'] = val_objectives
+    parameters['bdiv_valset'] = val_bdivs
     parameters['times'] = times
     parameters.to_csv(args.output_dir + '/parameters_with_results.txt',sep='\t',index=None)
 

--- a/SignatureAnalyzer-GPU.py
+++ b/SignatureAnalyzer-GPU.py
@@ -49,12 +49,13 @@ def run_parameter_sweep(parameters,data,args,Beta):
         nsig = [write_output(x[0],x[1],x[2],data.channel_names,data.sample_names,args.output_dir,
                       parameters['label'][idx+i]) for i,x in enumerate(result_list)]
         [nsigs.append(ns) for i,ns in enumerate(nsig)]
-        [times.append(time[3]) for i,time in enumerate(result_list)]
-        [objectives.append(obj[2]) for i,obj in enumerate(result_list)]
+        [times.append(time[4]) for i,time in enumerate(result_list)]
+        [objectives.append(obj[3]) for i,obj in enumerate(result_list)]
         idx += num_processes
 
     if idx < len(parameters):
         for i in range(len(parameters)-idx):
+            print(idx)
             W,H,mask,cost,time = run_method_engine(data, parameters.iloc[idx]['a'], parameters.iloc[idx]['phi'], parameters.iloc[idx]['b'], Beta,
                                                    args.prior_on_W, args.prior_on_H, parameters.iloc[idx]['K0'], args.tolerance, args.max_iter, args.use_val_set)
             nsig = write_output(W,H,mask,data.channel_names,data.sample_names,args.output_dir,
@@ -135,8 +136,15 @@ def main():
                                                   'the following headers:(a,phi,b,prior_on_W,prior_on_H,Beta,label) label '
                                                   'indicates the output stem of the results from each run.', required = False
                                                     ,default = None)
-    parser.add_argument('--use_val_set', help='whether to hold out data as a validation set during training.'
-                                              ' defaults to True when parameters_file is provided, False otherwise.', required=False, default=None)
+    parser.add_argument('--force_use_val_set', dest='use_val_set', action='store_true', help='override detaults and use a validation set no matter what,'
+                                                                                             'even when parameter search file is not passed.'
+                                                                                             'If neither --force_use_val_set or --force_no_val_set is passed, will default to create and evaluate on'
+                                                                                             'a held out validation set when parameters_file is provided, and not otherwise.')
+    parser.add_argument('--force_no_val_set', dest='use_val_set', action='store_false', help='override detaults and dont use a validation set no matter what,'
+                                                                                             'even when parameter search file is passed.'
+                                                                                             'If neither --force_use_val_set or --force_no_val_set is passed, will default to create and evaluate on'
+                                                                                             'a held out validation set when parameters_file is provided, and not otherwise.')
+    parser.set_defaults(use_val_set=None)
     args = parser.parse_args()
 
 


### PR DESCRIPTION
integrates with existing run_parameter_sweep() function. The code is currently set up such that the default behavior is to hold-out and report performance on a validation set whenever a parameters_file is provided, but a user can always override this default in either direction by passing the `force_use_val_set` or `force_no_val_set` args. Currently, validation is hard-coded to hold out approximately 20% of the data (see line 50 in ARD_NMF.py)... in future can update so that user defines percentage split, and also so that the heldout set percentage is exact, instead of approximate. The file parameters_with_results.txt has been updated to report both train and validate set results, where appropriate.